### PR TITLE
Integrated register form with cloudinary and backend for serving and …

### DIFF
--- a/client/src/components/Signup.jsx
+++ b/client/src/components/Signup.jsx
@@ -1,7 +1,9 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import './Signup.css';
 
 function Signup() {
+  const navigate = useNavigate()
   const [formData, setFormData] = useState({
     name: '',
     email: '',
@@ -21,7 +23,7 @@ function Signup() {
 
   const handleChange = (event) => {
     const { name, type, checked, files, value } = event.target;
-
+    
     if (type === 'file') {
       const file = files[0];
       setFormData((prevData) => ({ ...prevData, [name]: file }));
@@ -44,7 +46,27 @@ function Signup() {
       setMessage("Oops! Your passwords don't match. Try again.");
       return;
     }
-    console.log("Submitted:", formData);
+    const uploadData = new FormData();
+    uploadData.append('name', formData.name);
+    uploadData.append('email', formData.email);
+    uploadData.append('password', formData.password);
+    uploadData.append('image_url', formData.image_url);
+    uploadData.append('license', formData.license);
+    
+    fetch('/api/signup', {
+      method: 'POST',
+      body: uploadData,
+    })
+      .then((res) => res.json())
+      .then((user) => {
+        console.log(user);
+        navigate('/login')
+        setMessage("You’ve signed up! Check your email.");
+      })
+      .catch((err) => {
+        console.error(err);
+        setMessage(err);
+      });
     setMessage("You’ve signed up! Check your email.");
   };
 
@@ -61,7 +83,7 @@ function Signup() {
 
       {message && <p className="form-message">{message}</p>}
 
-      <form onSubmit={handleSubmit}>
+      <form onSubmit={handleSubmit} encType="multipart/form-data">
         <input type="text" name="name" placeholder="Name" value={formData.name} onChange={handleChange} required />
         <input type="email" name="email" placeholder="Email" value={formData.email} onChange={handleChange} required />
         <input type="password" name="password" placeholder="Password" value={formData.password} onChange={handleChange} required />
@@ -84,7 +106,11 @@ function Signup() {
             <label className="upload-label">Drivers license</label>
             <label className="upload-box">
               {preview.license ? (
-                <img src={preview.license} alt="License Preview" className="preview-image" />
+                 <iframe
+                    src={preview.license}
+                    width="100%"
+                    title="PDF Preview"
+                  ></iframe>
               ) : (
                 <div className="upload-icon" />
               )}

--- a/server/controllers/__init__.py
+++ b/server/controllers/__init__.py
@@ -1,5 +1,6 @@
 from server.controllers.authentication import Register
 from server.controllers.admin_controller import AdminSummary, BookingStats, PendingApprovals, Driver
-
+from server.controllers.image_controller import Images
 def addResource(api):
     api.add_resource(Register, '/api/signup')
+    api.add_resource(Images, '/api/images')

--- a/server/controllers/authentication.py
+++ b/server/controllers/authentication.py
@@ -9,7 +9,7 @@ from server.config import db
 class Register(Resource):
     def post(self):
         data = request.form
-        print(data)
+        print(data['name'])
         if User.query.filter_by(email=data.get('email')).first():
             return jsonify({'error': 'Email already registered.'}), 409
 
@@ -23,12 +23,12 @@ class Register(Resource):
         print(request.files)
         if 'image' in request.files:
             user.image_url = uploadImage(request.files['image_url'], user.name)
-        if 'document' in request.files:
-            user.license = uploadDocument(request.files['document'], user.name)
+        if request.files.get('license'):
+            user.license = uploadDocument(request.files['license'], user.name)
         else:
-            return jsonify({'error': 'Please upload your license.'}), 400
+            return make_response(jsonify({'error': 'Please upload your license.'}), 400)
         print(user.license)
         db.session.add(user)
         db.session.commit()
-
+        print(user.to_dict())
         return make_response( user.to_dict(), 201)

--- a/server/controllers/image_controller.py
+++ b/server/controllers/image_controller.py
@@ -1,3 +1,4 @@
+from flask_restful import Resource
 import cloudinary.uploader
 from cloudinary.utils import cloudinary_url
 def uploadImage(image, id):
@@ -31,3 +32,8 @@ def uploadDocument(document, id):
     print("****2. Upload an image****\nDelivery URL: ", srcURL, "\n")    
 
     return srcURL[0]
+
+class Images(Resource):
+    def get(self):
+        images = cloudinary.Search().expression('folder:"static"').execute()
+        return images

--- a/server/migrations/versions/f45842b6b733_initial_migration.py
+++ b/server/migrations/versions/f45842b6b733_initial_migration.py
@@ -1,6 +1,6 @@
 """Initial migration
 
-Revision ID: f45842b6b733
+Revision ID: 69e6fb24c4da
 Revises: 
 Create Date: 2025-07-23 22:53:35.756672
 
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision = 'f45842b6b733'
+revision = '69e6fb24c4da'
 down_revision = None
 branch_labels = None
 depends_on = None


### PR DESCRIPTION
This PR integrates the Register component with the backend API to allow users to create accounts via a POST request.
What’s Included
- Captures user input (name, email, password, optional image)
- Sends form data to `/api/register` (or your designated endpoint)
- Handles success and error responses (e.g., email already exists)
- Displays relevant feedback to the user
- Validates input before submission
- Uses  `fetch` for API calls