### PR TITLE
Implement edit functionality in AdminBookings with modal state

### DIFF
--- a/client/src/components/BookingDetailsModal.jsx
+++ b/client/src/components/BookingDetailsModal.jsx
@@ -1,7 +1,7 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import './BookingDetailsModal.css';
 
-const BookingDetailsModal = ({ onSave, onClose }) => {
+const BookingDetailsModal = ({ onSave, onClose, initialData }) => {
   const [formData, setFormData] = useState({
     firstName: '',
     secondName: '',
@@ -13,6 +13,12 @@ const BookingDetailsModal = ({ onSave, onClose }) => {
     seatNumber: '',
   });
 
+  useEffect(() => {
+    if (initialData) {
+      setFormData(initialData);
+    }
+  }, [initialData]);
+
   const handleChange = (e) => {
     const { name, value } = e.target;
     setFormData(prev => ({ ...prev, [name]: value }));
@@ -21,13 +27,13 @@ const BookingDetailsModal = ({ onSave, onClose }) => {
   const handleSubmit = (e) => {
     e.preventDefault();
 
-    const newBooking = {
+    const updatedBooking = {
       ...formData,
       status: 'Booked',
-      bookDate: new Date().toLocaleString(), 
+      bookDate: formData.bookDate || new Date().toLocaleString(),
     };
 
-    onSave(newBooking);
+    onSave(updatedBooking);
     onClose();
   };
 
@@ -35,68 +41,17 @@ const BookingDetailsModal = ({ onSave, onClose }) => {
     <div className="booking-modal-overlay">
       <div className="booking-modal-container">
         <button className="booking-modal-close" onClick={onClose}>×</button>
-        <h3 className="booking-modal-title">Add Booking</h3>
+        <h3 className="booking-modal-title">{initialData ? 'Edit Booking' : 'Add Booking'}</h3>
         <form onSubmit={handleSubmit}>
-          <input
-            name="firstName"
-            placeholder="First Name"
-            value={formData.firstName}
-            onChange={handleChange}
-            required
-          />
-          <input
-            name="secondName"
-            placeholder="Second Name"
-            value={formData.secondName}
-            onChange={handleChange}
-            required
-          />
-          <input
-            name="email"
-            placeholder="Email"
-            type="email"
-            value={formData.email}
-            onChange={handleChange}
-            required
-          />
-          <input
-            name="phone"
-            placeholder="Phone"
-            type="tel"
-            value={formData.phone}
-            onChange={handleChange}
-            required
-          />
-          <input
-            name="identification"
-            placeholder="ID or Passport No"
-            value={formData.identification}
-            onChange={handleChange}
-            required
-          />
-          <input
-            name="nationality"
-            placeholder="Nationality"
-            value={formData.nationality}
-            onChange={handleChange}
-            required
-          />
-          <input
-            name="tripId"
-            placeholder="Trip ID"
-            value={formData.tripId}
-            onChange={handleChange}
-            required
-          />
-          <input
-            name="seatNumber"
-            placeholder="Seat Number"
-            value={formData.seatNumber}
-            onChange={handleChange}
-            required
-          />
-
-          <button type="submit" className="btn-submit">Add Booking</button>
+          <input name="firstName" placeholder="First Name" value={formData.firstName} onChange={handleChange} required />
+          <input name="secondName" placeholder="Second Name" value={formData.secondName} onChange={handleChange} required />
+          <input name="email" placeholder="Email" type="email" value={formData.email} onChange={handleChange} required />
+          <input name="phone" placeholder="Phone" type="tel" value={formData.phone} onChange={handleChange} required />
+          <input name="identification" placeholder="ID or Passport No" value={formData.identification} onChange={handleChange} required />
+          <input name="nationality" placeholder="Nationality" value={formData.nationality} onChange={handleChange} required />
+          <input name="tripId" placeholder="Trip ID" value={formData.tripId} onChange={handleChange} required />
+          <input name="seatNumber" placeholder="Seat Number" value={formData.seatNumber} onChange={handleChange} required />
+          <button type="submit" className="btn-submit">{initialData ? 'Save Changes' : 'Add Booking'}</button>
           <button type="button" className="btn-cancel" onClick={onClose}>Cancel</button>
         </form>
       </div>

--- a/client/src/pages/AdminBookings.jsx
+++ b/client/src/pages/AdminBookings.jsx
@@ -4,13 +4,34 @@ import BookingDetailsModal from '../components/BookingDetailsModal';
 import CustomerDetailsModal from '../components/CustomerDetailsModal';
 
 const AdminBookings = () => {
-  const [showModal, setShowModal] = useState(false);
+  const [bookings, setBookings] = useState([]);
+  const [editingBooking, setEditingBooking] = useState(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
   const [showCustomerModal, setShowCustomerModal] = useState(false);
   const [selectedCustomer, setSelectedCustomer] = useState(null);
-  const [bookings, setBookings] = useState([]);
 
-  const handleAddBooking = (newBooking) => {
-    setBookings([...bookings, newBooking]);
+  const handleSaveBooking = (booking) => {
+    if (editingBooking) {
+      const updatedList = bookings.map((b) =>
+        b.bookDate === editingBooking.bookDate ? booking : b
+      );
+      setBookings(updatedList);
+    } else {
+      setBookings([...bookings, booking]);
+    }
+
+    setIsModalOpen(false);
+    setEditingBooking(null);
+  };
+
+  const handleAddClick = () => {
+    setEditingBooking(null);
+    setIsModalOpen(true);
+  };
+
+  const handleEditClick = (booking) => {
+    setEditingBooking(booking);
+    setIsModalOpen(true);
   };
 
   const handleViewCustomer = (customer) => {
@@ -22,7 +43,7 @@ const AdminBookings = () => {
     <div className="container py-4">
       <div className="d-flex justify-content-between align-items-center mb-4">
         <h2>Manage Bookings</h2>
-        <button className="btn btn-light" onClick={() => setShowModal(true)}>Add Booking</button>
+        <button className="btn btn-light" onClick={handleAddClick}>Add Booking</button>
       </div>
 
       <div className="mb-3">
@@ -58,7 +79,7 @@ const AdminBookings = () => {
                 <td className="text-primary">Booked</td>
                 <td>11/07/2025 19:00</td>
                 <td>
-                  <a href="#" className="text-decoration-none text-primary fw-medium">Edit</a>
+                  <span className="btn btn-sm btn-outline-primary disabled">Edit</span>
                 </td>
               </tr>
             ))}
@@ -72,13 +93,8 @@ const AdminBookings = () => {
                 <td className="text-primary">{b.status}</td>
                 <td>{b.bookDate}</td>
                 <td className="d-flex gap-2">
-                  <a href="#" className="btn btn-sm btn-outline-primary">Edit</a>
-                  <button
-                    className="btn btn-sm btn-outline-info"
-                    onClick={() => handleViewCustomer(b)}
-                  >
-                    View Details
-                  </button>
+                  <button className="btn btn-sm btn-outline-primary" onClick={() => handleEditClick(b)}>Edit</button>
+                  <button className="btn btn-sm btn-outline-info" onClick={() => handleViewCustomer(b)}>View Details</button>
                 </td>
               </tr>
             ))}
@@ -86,10 +102,14 @@ const AdminBookings = () => {
         </table>
       </div>
 
-      {showModal && (
+      {isModalOpen && (
         <BookingDetailsModal
-          onSave={handleAddBooking}
-          onClose={() => setShowModal(false)}
+          onSave={handleSaveBooking}
+          onClose={() => {
+            setIsModalOpen(false);
+            setEditingBooking(null);
+          }}
+          initialData={editingBooking}
         />
       )}
 


### PR DESCRIPTION
I have updated the bookings section to allow admins to edit booking details directly from the table. When the “Edit” button is clicked, a form opens with all the customer’s current information already filled in. The admin can then change details like the name, email, trip ID, or seat number and save the updates. This makes it easier to correct mistakes or update information without creating a new booking.